### PR TITLE
Enable polygon drawing on maps-web

### DIFF
--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -47,6 +47,7 @@
         "classnames": "^2.3.2",
         "deep-equal": "^2.2.3",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
         "react-leaflet": "^4.2.1"
     },
     "devDependencies": {
@@ -61,6 +62,7 @@
         "@types/deep-equal": "^1.0.1",
         "@types/leaflet": "^1.9.3",
         "@types/react-leaflet": "^2.8.3",
+        "@types/leaflet-draw": "^1.0.12",
         "cross-env": "^7.0.3"
     }
 }

--- a/packages/pluggableWidgets/maps-web/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-web/src/Maps.tsx
@@ -7,6 +7,7 @@ import { getCurrentUserLocation } from "./utils/location";
 import { Marker } from "../typings/shared";
 import { translateZoom } from "./utils/zoom";
 import "leaflet/dist/leaflet.css";
+import "leaflet-draw/dist/leaflet.draw.css";
 import "./ui/Maps.scss";
 
 export default function Maps(props: MapsContainerProps): ReactNode {

--- a/packages/pluggableWidgets/maps-web/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-web/src/Maps.tsx
@@ -51,6 +51,8 @@ export default function Maps(props: MapsContainerProps): ReactNode {
             zoomLevel={translateZoom(props.zoom)}
             geoJSON={typeof props.geoJSON === "string" ? props.geoJSON : props.geoJSON?.value}
             onGeoJSONClick={props.onGeoJSONClick}
+            enablePolygonDrawing={props.enablePolygonDrawing}
+            polygonGeoJSON={props.polygonGeoJSON}
         />
     );
 }

--- a/packages/pluggableWidgets/maps-web/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-web/src/Maps.xml
@@ -271,5 +271,18 @@
                 <description>Triggered when a GeoJSON feature is clicked. The input parameter should match the GeoJSON feature entity.</description>
             </property>
         </propertyGroup>
+        <propertyGroup caption="Drawing">
+            <property key="enablePolygonDrawing" type="boolean" defaultValue="false">
+                <caption>Enable polygon drawing</caption>
+                <description>When enabled, users can draw a polygon on the map.</description>
+            </property>
+            <property key="polygonGeoJSON" type="attribute" required="false">
+                <caption>Polygon GeoJSON</caption>
+                <description>Attribute that will store the drawn polygon as a GeoJSON string.</description>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+        </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/maps-web/src/ui/Maps.scss
+++ b/packages/pluggableWidgets/maps-web/src/ui/Maps.scss
@@ -64,13 +64,3 @@ Leaflet maps
     transform: translate(-50%, -50%);
 }
 
-.widget-draw-polygon-btn {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 400;
-    background-color: #ffffff;
-    border: 1px solid #ccc;
-    padding: 4px 8px;
-    cursor: pointer;
-}

--- a/packages/pluggableWidgets/maps-web/src/ui/Maps.scss
+++ b/packages/pluggableWidgets/maps-web/src/ui/Maps.scss
@@ -63,3 +63,14 @@ Leaflet maps
 .custom-leaflet-map-icon-marker-icon {
     transform: translate(-50%, -50%);
 }
+
+.widget-draw-polygon-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 400;
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    cursor: pointer;
+}

--- a/packages/pluggableWidgets/maps-web/typings/MapsProps.d.ts
+++ b/packages/pluggableWidgets/maps-web/typings/MapsProps.d.ts
@@ -4,7 +4,7 @@
  * @author Mendix Widgets Framework Team
  */
 import { CSSProperties } from "react";
-import { ActionValue, DynamicValue, ListValue, ListActionValue, ListAttributeValue, WebImage } from "mendix";
+import { ActionValue, DynamicValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, WebImage } from "mendix";
 import { Big } from "big.js";
 
 export type LocationTypeEnum = "address" | "latlng";
@@ -99,6 +99,8 @@ export interface MapsContainerProps {
     googleMapId: string;
     geoJSON?: DynamicValue<string>;
     onGeoJSONClick?: ActionValue;
+    enablePolygonDrawing: boolean;
+    polygonGeoJSON?: EditableValue<string>;
 }
 
 export interface MapsPreviewProps {
@@ -137,4 +139,6 @@ export interface MapsPreviewProps {
     googleMapId: string;
     geoJSON: string;
     onGeoJSONClick: {} | null;
+    enablePolygonDrawing: boolean;
+    polygonGeoJSON: string;
 }

--- a/packages/pluggableWidgets/maps-web/typings/shared.d.ts
+++ b/packages/pluggableWidgets/maps-web/typings/shared.d.ts
@@ -1,5 +1,6 @@
 import { Dimensions } from "@mendix/widget-plugin-platform/utils/get-dimensions";
 import { CSSProperties } from "react";
+import { ActionValue, EditableValue } from "mendix";
 export interface ModeledMarker {
     address?: string;
     latitude?: number;
@@ -31,4 +32,6 @@ export interface SharedProps extends Dimensions {
     style?: CSSProperties;
     geoJSON?: string;
     onGeoJSONClick?: ActionValue;
+    enablePolygonDrawing: boolean;
+    polygonGeoJSON?: EditableValue<string>;
 }


### PR DESCRIPTION
## Summary
- allow drawing polygons on Leaflet map
- expose attribute to store drawn polygon as GeoJSON
- add widget properties for polygon drawing

## Testing
- `pnpm --filter @mendix/maps-web test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493ca96fb0832390e1f0ce4a32a1fb